### PR TITLE
explicitly load dplyr in vignette

### DIFF
--- a/vignettes/prospective-power.Rmd
+++ b/vignettes/prospective-power.Rmd
@@ -16,6 +16,7 @@ vignette: >
   
 ```{r setup, message = FALSE}
   library(postcard)
+  library(dplyr)
 withr::local_seed(1395878)
 withr::local_options(list(postcard.verbose = 0))
 ```


### PR DESCRIPTION
Hello! We'll be releasing version 2.0 of the tune package in the next few weeks. 

Initial testing shows a breakage for the postcard. We're moving to the base R pipe, so we don't import or export `%>%` anymore. This breaks one of the vignettes, so we explicitly load dplyr now. 